### PR TITLE
Remove deploy_url

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,6 @@ makedocs(;
     format=DocumenterVitepress.MarkdownVitepress(
         repo = "github.com/brian-dellabetta/Fusion.jl",
         devbranch = "main",
-        deploy_url = "brian-dellabetta.github.io/Fusion.jl",
     ),
     draft = false,
     source = "src",


### PR DESCRIPTION
You don't actually need this if going through the default Github URL, and without a `https://` it interprets the entire URL as the base path from the URL.  This is probably the source of a lot of your issues.