### PR TITLE
Feature/bd/particle into barrier

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,16 @@ authors = ["Brian Dellabetta <brian.dellabetta@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
+QuantumOptics = "6e0679c1-51ea-5a7c-ac74-d61b76210b0c"
 
 [compat]
+CairoMakie = "0.12.15"
 DataStructures = "0.18.20"
 Observables = "0.5.5"
+QuantumOptics = "1.2.1"

--- a/src/Fusion.jl
+++ b/src/Fusion.jl
@@ -7,7 +7,8 @@ Line3f = Tuple{Point3f,Point3f}
 include("lattice.jl")
 include("atom.jl")
 include("plot.jl")
+include("particle_into_barrier.jl")
 
-export Atom, Lattice, create_movie, step!, Point3f, Line3f
+export Atom, Lattice, create_movie, step!, Point3f, Line3f, create_plot
 
 end

--- a/src/particle_into_barrier.jl
+++ b/src/particle_into_barrier.jl
@@ -5,71 +5,70 @@ using CairoMakie
 using Makie
 
 function create_plot(;
-    xmin::Integer=-30,
-    xmax::Integer=30,
-    n_points::Integer=200,
+    xmin::Real=0,
+    xmax::Real=4000.0,
+    x0::Real=15,
+    n_points::Integer=2000,
     m::Real=1.0,
-    p0s::Vector{<:Real}=[sqrt(0.1), 1, sqrt(2), sqrt(3), 2],
-    V0::Real=1.0, # Height of Barrier
+    p0s::Vector{<:Real}=[0.0, sqrt(0.1), 1, sqrt(2), sqrt(3), 2],
+    V0::Real=500.0, # Max height of Coulomb Barrier
+    d::Real=2000.0, #Width of Coulomb Barrier
 )
     CairoMakie.activate!()
 
     b_position = PositionBasis(xmin, xmax, n_points)
     b_momentum = MomentumBasis(b_position)
-
-    #TODO Coulomb repulsion of 2 charged particles, 1/r 
-    function V_coulomb(x)
-        if x < -d / 2 || x > d / 2
-            return 0.0
-        else
-            return V0
-        end
-    end
-    V = potentialoperator(b_position, V_coulomb)
-
     Txp = transform(b_position, b_momentum)
     Tpx = transform(b_momentum, b_position)
-
-    #Momentum operator p̂
-    p̂ = m > 1e-15 ? momentum(b_momentum)^2 / (2 * m) : momentum(b_momentum)
-
-    Hkin = LazyProduct(Txp, p̂, Tpx)
-    H = LazySum(Hkin, V)
-
     xpoints = samplepoints(b_position)
 
-    x0 = -15
+    #Hamiltonian kinetic term is either parabolic (p^2/2m) or linear (p)
+    Hkin = begin
+        op = m > 1e-15 ? (momentum(b_momentum)^2 / (2 * m)) : momentum(b_momentum)
+        LazyProduct(Txp, op, Tpx)
+    end
+
+    #Coulomb repulsion of 2 charged particles, 1/r 
+    function V_Coulomb(x)
+        if abs(x - xmax) > d
+            return V0 / abs(x - (xmax - d))
+        else
+            return 0.0 #-V0 * 2
+        end
+    end
+    V = potentialoperator(b_position, V_Coulomb)
+
+    H = LazySum(Hkin, V)
+
     sigma0 = 4
     timecuts = 20
+    tmax = 2400
 
     fig = Figure()
     ax = Axis(fig[1, 1], yautolimitmargin=(0.1, 0.1), xautolimitmargin=(0.1, 0.1))
     colors = Makie.wong_colors()
 
-    for i_p in eachindex(p0s)
-        p0 = p0s[i_p]
+    for (i_p, p0) in enumerate(p0s)
         Ψ₀ = gaussianstate(b_position, x0, p0, sigma0)
         scaling = 1.0 / maximum(abs.(Ψ₀.data))^2 / 5
         n0 = abs.(Ψ₀.data) .^ 2 .* scaling
 
-        tmax = 2 * abs(x0) / (p0 + 0.2)
         T = collect(range(0.0, stop=tmax, length=timecuts))
-        tout, Ψt = timeevolution.schroedinger(T, Ψ₀, H)
+        tout, Ψt = timeevolution.schroedinger(T, Ψ₀, H; maxiters=1e8)
 
         offset = real.(expect(Hkin, Ψ₀))
         #plot initial state
         lines!(ax, xpoints, n0 .+ offset, linestyle=:dash, color=colors[i_p])
         #plot intermediate states
-        for i = 1:length(T)
-            Ψ = Ψt[i]
+        for (i, Ψ) in enumerate(Ψt)
             n = abs.(Ψ.data) .^ 2 .* scaling
-            lines!(ax, xpoints, n .+ offset, alpha=0.3, color=colors[i_p])
+            lines!(ax, xpoints, n .+ offset, alpha=(i / timecuts), color=colors[i_p])
         end
         #plot final state
         nt = abs.(Ψt[timecuts].data) .^ 2 * scaling
         lines!(ax, xpoints, nt .+ offset, color=colors[i_p])
     end
-    y = V_barrier.(xpoints)
+    y = V_Coulomb.(xpoints) ./ 1e3
     lines!(ax, xpoints, y, color=:black)
 
     fig

--- a/src/particle_into_barrier.jl
+++ b/src/particle_into_barrier.jl
@@ -1,0 +1,76 @@
+# https://docs.qojulia.org/examples/particle-into-barrier/
+
+using QuantumOptics
+using CairoMakie
+using Makie
+
+function create_plot(;
+    xmin::Integer=-30,
+    xmax::Integer=30,
+    n_points::Integer=200,
+    m::Real=1.0,
+    p0s::Vector{<:Real}=[sqrt(0.1), 1, sqrt(2), sqrt(3), 2],
+    V0::Real=1.0, # Height of Barrier
+)
+    CairoMakie.activate!()
+
+    b_position = PositionBasis(xmin, xmax, n_points)
+    b_momentum = MomentumBasis(b_position)
+
+    #TODO Coulomb repulsion of 2 charged particles, 1/r 
+    function V_coulomb(x)
+        if x < -d / 2 || x > d / 2
+            return 0.0
+        else
+            return V0
+        end
+    end
+    V = potentialoperator(b_position, V_coulomb)
+
+    Txp = transform(b_position, b_momentum)
+    Tpx = transform(b_momentum, b_position)
+
+    #Momentum operator p̂
+    p̂ = m > 1e-15 ? momentum(b_momentum)^2 / (2 * m) : momentum(b_momentum)
+
+    Hkin = LazyProduct(Txp, p̂, Tpx)
+    H = LazySum(Hkin, V)
+
+    xpoints = samplepoints(b_position)
+
+    x0 = -15
+    sigma0 = 4
+    timecuts = 20
+
+    fig = Figure()
+    ax = Axis(fig[1, 1], yautolimitmargin=(0.1, 0.1), xautolimitmargin=(0.1, 0.1))
+    colors = Makie.wong_colors()
+
+    for i_p in eachindex(p0s)
+        p0 = p0s[i_p]
+        Ψ₀ = gaussianstate(b_position, x0, p0, sigma0)
+        scaling = 1.0 / maximum(abs.(Ψ₀.data))^2 / 5
+        n0 = abs.(Ψ₀.data) .^ 2 .* scaling
+
+        tmax = 2 * abs(x0) / (p0 + 0.2)
+        T = collect(range(0.0, stop=tmax, length=timecuts))
+        tout, Ψt = timeevolution.schroedinger(T, Ψ₀, H)
+
+        offset = real.(expect(Hkin, Ψ₀))
+        #plot initial state
+        lines!(ax, xpoints, n0 .+ offset, linestyle=:dash, color=colors[i_p])
+        #plot intermediate states
+        for i = 1:length(T)
+            Ψ = Ψt[i]
+            n = abs.(Ψ.data) .^ 2 .* scaling
+            lines!(ax, xpoints, n .+ offset, alpha=0.3, color=colors[i_p])
+        end
+        #plot final state
+        nt = abs.(Ψt[timecuts].data) .^ 2 * scaling
+        lines!(ax, xpoints, nt .+ offset, color=colors[i_p])
+    end
+    y = V_barrier.(xpoints)
+    lines!(ax, xpoints, y, color=:black)
+
+    fig
+end


### PR DESCRIPTION
First attempt at using time-evolving schrödinger equation to simulate the dynamics of a charged particle approaching another, with repulsive Coulomb potential followed by a strong attractive potential beyond a threshold position. If `m=0`, the model will switch to a Hamiltonian with linear dispersion instead of parabolic.

While it is very promising that the linear dispersion appears to tunnel at higher probability than parabolic, I am hitting a cutoff error that is causing the wave function to not be normalized at large time steps.

`create_plot(m=0.0, p0s=[0, 10], V0=500.)` (i.e. linear dispersion) yields
<img width="1107" alt="Screenshot 2025-02-06 at 8 06 49 AM" src="https://github.com/user-attachments/assets/328890c1-d193-4e71-b9b5-79204526c9b9" />

and `create_plot(m=1.0, p0s=[0, 10], V0=500.)` (i.e. parabolic dispersion) yields
<img width="1199" alt="Screenshot 2025-02-06 at 8 06 25 AM" src="https://github.com/user-attachments/assets/b1c5bc90-4c4d-40eb-9756-e41d810e4e78" />

